### PR TITLE
Add lessons + fix typo

### DIFF
--- a/chapter1.md
+++ b/chapter1.md
@@ -13,7 +13,7 @@ lessons:
   - nb_of_exercises: 5
     title: Welcome to the course!
   - nb_of_exercises: 4
-    title: SELECTing colums
+    title: SELECTing columns
   - nb_of_exercises: 2
     title: Learning to COUNT
 ---

--- a/chapter1.md
+++ b/chapter1.md
@@ -9,6 +9,13 @@ free_preview: true
 attachments:
   slides_link: >-
     https://s3.amazonaws.com/assets.datacamp.com/production/course_1946/slides/chapter1.pdf
+lessons:
+  - nb_of_exercises: 5
+    title: Welcome to the course!
+  - nb_of_exercises: 4
+    title: SELECTing colums
+  - nb_of_exercises: 2
+    title: Learning to COUNT
 ---
 
 ## Welcome to the course!

--- a/chapter2.md
+++ b/chapter2.md
@@ -4,6 +4,15 @@ description: >-
   This chapter builds on the first by teaching you how to filter tables for rows
   satisfying some criteria of interest. You'll learn how to use basic comparison
   operators, combine multiple criteria, match patterns in text, and much more.
+lessons:
+  - nb_of_exercises: 3
+    title: Simple filtering
+  - nb_of_exercises: 3
+    title: Combining filters
+  - nb_of_exercises: 3
+    title: Advanced filtering
+  - nb_of_exercises: 3
+    title: Patterns and missing values
 ---
 
 ## Filtering results

--- a/chapter3.md
+++ b/chapter3.md
@@ -4,6 +4,11 @@ description: >-
   This chapter teaches you how to use aggregate functions to summarize data and
   gain useful insights. You'll also learn about arithmetic in SQL and how to use
   aliases to make your results more readable.
+lessons:
+  - nb_of_exercises: 4
+    title: Aggregate functions
+  - nb_of_exercises: 2
+    title: Aliasing
 ---
 
 ## Aggregate functions

--- a/chapter4.md
+++ b/chapter4.md
@@ -3,6 +3,13 @@ title: Sorting and grouping
 description: >-
   This chapter provides a brief introduction to sorting and grouping your
   results.
+lessons:
+  - nb_of_exercises: 5
+    title: Sorting
+  - nb_of_exercises: 4
+    title: Grouping
+  - nb_of_exercises: 3
+    title: Bringing it all together
 ---
 
 ## ORDER BY


### PR DESCRIPTION
I noticed a typo in one of the lesson titles in this course: `SELECTing colums` should be `SELECTing columns`. In order to edit lessons for this course, I first had to add them - Tim did that using a new button in Teach.
This is good test to find out if this new feature works!